### PR TITLE
Issue #156 - Load Monitored Area Images From Dynamic Files

### DIFF
--- a/BackEnd/BackEndServer/BackEndServer.csproj
+++ b/BackEnd/BackEndServer/BackEndServer.csproj
@@ -28,5 +28,6 @@
     <Folder Include="Controllers\APIControllers\" />
     <Folder Include="Classes\DataResponseClasses\" />
     <Folder Include="wwwroot\lib\materialize\fonts" />
+    <Folder Include="wwwroot\temp\" />
   </ItemGroup>
 </Project>

--- a/BackEnd/BackEndServer/Controllers/FrontEndControllers/CameraController.cs
+++ b/BackEnd/BackEndServer/Controllers/FrontEndControllers/CameraController.cs
@@ -7,6 +7,7 @@ using BackEndServer.Models.DBModels;
 using Microsoft.AspNetCore.Http;
 using System.IO;
 using Castle.Core.Internal;
+using System.Threading.Tasks;
 
 // For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -44,6 +45,7 @@ namespace BackEndServer.Controllers.FrontEndControllers
             {
                 return RedirectToAction("SignIn", "Home");
             }
+
             CameraStatistics cameraStatisticsModel = CameraService.getCameraStatisticsForNowById(cameraId);
             
             if (cameraStatisticsModel != null)
@@ -96,7 +98,7 @@ namespace BackEndServer.Controllers.FrontEndControllers
         }
 
         [HttpPost]
-        public IActionResult RegisterCamera(CameraDetails cameraDetails)
+        public async Task<IActionResult> RegisterCamera(CameraDetails cameraDetails)
         {
             int? currentUserId = HttpContext.Session.GetInt32("currentUserId");
 
@@ -141,7 +143,7 @@ namespace BackEndServer.Controllers.FrontEndControllers
                         using (var fileStream = new FileStream(fullFilePath, FileMode.Create))
                         {
                             // NOTE: If this was for the Edit page, we would have to delete the previous picture first.
-                            image.CopyToAsync(fileStream);
+                            await image.CopyToAsync(fileStream);
                         }
                     }
                 }

--- a/BackEnd/BackEndServer/Database/jetson_schema.sql
+++ b/BackEnd/BackEndServer/Database/jetson_schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `jetson`.`camera` (
   `brand` VARCHAR(45) NULL DEFAULT NULL, -- TODO: Check if NULL DEFAULT NULL makes sense or just really stupid
   `model` VARCHAR(45) NULL DEFAULT NULL,
   `resolution` VARCHAR(45) NULL DEFAULT NULL,
-  `image_path` VARCHAR(100) NULL DEFAULT NULL,
+  `image_path` VARCHAR(150) NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `fk_camera_Address`
     FOREIGN KEY (`location_id`)

--- a/BackEnd/BackEndServer/Models/ViewModels/CameraInformation.cs
+++ b/BackEnd/BackEndServer/Models/ViewModels/CameraInformation.cs
@@ -10,13 +10,15 @@ namespace BackEndServer.Models.ViewModels
         public string CameraName { get; set; }
         public string ImagePath { get; set; }
         public GraphStatistics GraphStatistics { get; set; }
+        public string TempImagePath { get; set; }
 
-        
+
         public CameraInformation(int cameraId, string cameraRoomName, string imagePath){
             CameraId = cameraId;
             CameraRoomName = cameraRoomName;
             CameraName = cameraRoomName + " Camera";
             ImagePath = imagePath;
+            TempImagePath = null;
         }
 
         public CameraInformation(int cameraId, string cameraRoomName, string cameraName, string imagePath)
@@ -25,6 +27,7 @@ namespace BackEndServer.Models.ViewModels
             CameraRoomName = cameraRoomName;
             CameraName = cameraName;
             ImagePath = imagePath;
+            TempImagePath = null;
         }
 
         public CameraInformation(DatabaseCamera dbCamera) : this(dbCamera.CameraId, dbCamera.MonitoredArea, dbCamera.CameraName, dbCamera.ImagePath) {}

--- a/BackEnd/BackEndServer/Models/ViewModels/CameraStatistics.cs
+++ b/BackEnd/BackEndServer/Models/ViewModels/CameraStatistics.cs
@@ -14,5 +14,6 @@ namespace BackEndServer.Models.ViewModels
         public CameraInformation CameraInformation { get; set; }
         public CameraDetails CameraDetails { get; set; }
         public GraphStatistics GraphStatistics { get; set; }
+        public string TempImagePath { get; set; }
     }
 }

--- a/BackEnd/BackEndServer/Services/CameraService.cs
+++ b/BackEnd/BackEndServer/Services/CameraService.cs
@@ -31,9 +31,67 @@ namespace BackEndServer.Services
         public CameraInformationList GetCamerasAtLocationForUser(int locationId, int userId)
         {
             List<DatabaseCamera> dbCameraList = _dbQueryService.GetCamerasForLocationForUser(locationId, userId);
-            return new CameraInformationList(dbCameraList);
+
+            CameraInformationList listOfCameraInfo = new CameraInformationList(dbCameraList);
+
+            return InitialiseImagesBeforeDisplaying(listOfCameraInfo);
         }
-        
+
+        private CameraInformationList InitialiseImagesBeforeDisplaying(CameraInformationList list)
+        {
+            foreach(CameraInformation camInfo in list.CameraList)
+            {
+                camInfo.TempImagePath = GenerateTempImageAndTempPath(camInfo.ImagePath);
+            }
+
+            return list;
+        }
+
+        private string GenerateTempImageAndTempPath(string imagePath)
+        {
+            // If the camera has a value in the image_path column of the Camera table in the database, if not a question mark will be displayed instead.
+            if (String.IsNullOrWhiteSpace(imagePath) == false)
+            {
+                // Ensure the image file still exists on the server, if not a question mark will be displayed instead.
+                if (File.Exists(imagePath))
+                {
+                    /*
+                     NOTE: To create/delete/overwrite file in the wwwroot directory, physical file paths must be used
+                            and not virual paths (using ~). Use RootDirectoryTools.cs in HelperServices.
+                    */
+
+                    // 1. Extract the FileName from the path stored in the database.
+                    string fileName = Path.GetFileName(imagePath);
+
+                    // 2. Create the full file output path (physical).
+                    string tempPath = Path.Combine(RootDirectoryTools.GetWWWRootPhysicalPath(), fileName);
+
+                    // 3. Delete any previous file in the temp folder associated to the camera.
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
+
+                    // 4. Copy the image from the path in the "...\BackEnd\BackEndServer\ImageStorage\CameraImages" to the phycal wwwroot path's "\temp" folder.
+                    File.Copy
+                    (
+                        // Source Image Path (stored in the ImageStorage\CameraImages folder in the project.)
+                        imagePath,
+                        // Write to the wwwroot directory's temp path (physical), output filename remains the same. 
+                        Path.Combine(RootDirectoryTools.GetWWWRootTempFolderPhysicalPath(), fileName),
+                        // If file was not deleted properly, ensure the existing file is overwritten.
+                        true
+                    );
+
+                    // 5. Set the View Model object's "TempImagePath" attribute to the appropriate 
+                    // value for use in the img element's src attribute to locate the image in the wwwroot.
+                    return String.Concat(RootDirectoryTools.GetWWWRootTempFolderVirtualPathForHTML(), "/", fileName);
+                }
+            }
+
+            return null;
+        }
+
         public CameraInformationList getCamerasAtLocation(int locationId)
         {
             List<DatabaseCamera> dbCameraList = _dbQueryService.GetCamerasForLocation(locationId);
@@ -78,45 +136,7 @@ namespace BackEndServer.Services
                     cameraStatistics.CameraDetails.Location = new LocationDetails(_dbQueryService.GetLocationById(camera.LocationId.Value));
                 }
 
-                // If the camera has a value in the image_path column of the Camera table in the database, if not a question mark will be displayed instead.
-                if (String.IsNullOrWhiteSpace(camera.ImagePath) == false)
-                {
-                    // Ensure the image file still exists on the server, if not a question mark will be displayed instead.
-                    if (File.Exists(camera.ImagePath))
-                    {
-                        /*
-                         NOTE: To create/delete/overwrite file in the wwwroot directory, physical file paths must be used
-                                and not virual paths (using ~). Use RootDirectoryTools.cs in HelperServices.
-                        */
-                         
-                        // 1. Extract the FileName from the path stored in the database.
-                        string fileName = Path.GetFileName(camera.ImagePath);
-
-                        // 2. Create the full file output path (physical).
-                        string tempPath = Path.Combine(RootDirectoryTools.GetWWWRootPhysicalPath(), fileName);
-
-                        // 3. Delete any previous file in the temp folder associated to the camera.
-                        if (File.Exists(tempPath))
-                        {
-                            File.Delete(tempPath);
-                        }
-
-                        // 4. Copy the image from the path in the "...\BackEnd\BackEndServer\ImageStorage\CameraImages" to the phycal wwwroot path's "\temp" folder.
-                        File.Copy
-                        (
-                            // Source Image Path (stored in the ImageStorage\CameraImages folder in the project.)
-                            camera.ImagePath, 
-                            // Write to the wwwroot directory's temp path (physical), output filename remains the same. 
-                            Path.Combine(RootDirectoryTools.GetWWWRootTempFolderPhysicalPath(), fileName), 
-                            // If file was not deleted properly, ensure the existing file is overwritten.
-                            true
-                        );
-
-                        // 5. Set the CameraStatistic View Model object's "TempImagePath" attribute to the appropriate 
-                        // value for use in the img element's src attribute to locate the image in the wwwroot.
-                        cameraStatistics.TempImagePath = String.Concat(RootDirectoryTools.GetWWWRootTempFolderVirtualPathForHTML(), "/", fileName);
-                    }
-                }
+                cameraStatistics.TempImagePath = GenerateTempImageAndTempPath(camera.ImagePath);
 
                 return cameraStatistics;
             }

--- a/BackEnd/BackEndServer/Services/HelperServices/RootDirectoryTools.cs
+++ b/BackEnd/BackEndServer/Services/HelperServices/RootDirectoryTools.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+
+namespace BackEndServer.Services.HelperServices
+{
+    public static class RootDirectoryTools
+    {
+        public static string GetWWWRootPhysicalPath()
+        {
+            return Path.Combine
+            (
+                // "<PROJECT_ROOT>\\BackEnd\\BackEndServer\\bin\\Debug\\netcoreapp2.0\\"
+                AppDomain.CurrentDomain.BaseDirectory, 
+                // Go up 3 parent levels.
+                @"..\..\..\",
+                // Add the wwwroot child directory of the BackEndServer parent directory.
+                @"wwwroot"
+            );
+        }
+
+        public static string GetWWWRootTempFolderPhysicalPath()
+        {
+            return Path.Combine(GetWWWRootPhysicalPath(), @"temp");
+        }
+
+        public static string GetWWWRootVirtualPathForHTML()
+        {
+            return @"/";
+        }
+
+        public static string GetWWWRootTempFolderVirtualPathForHTML()
+        {
+            return Path.Combine(GetWWWRootVirtualPathForHTML(), @"temp");
+        }
+    }
+}

--- a/BackEnd/BackEndServer/Startup.cs
+++ b/BackEnd/BackEndServer/Startup.cs
@@ -11,7 +11,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using BackEndServer.Services;
 using BackEndServer.Services.AbstractServices;
+using BackEndServer.Services.HelperServices;
 using BackEndServer.Services.PlaceholderServices;
+using System.IO;
 
 namespace BackEndServer
 {
@@ -67,8 +69,10 @@ namespace BackEndServer
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
         {
+            applicationLifetime.ApplicationStopping.Register(OnShutdown);
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -87,5 +91,27 @@ namespace BackEndServer
                     template: "{controller=Home}/{action=SignIn}/{id?}");
             });
         }
+
+        // This code is called when the application is stopped.
+        private void OnShutdown()
+        {
+            // Deletes all files copied into the temp folder when testing. Prevents uploading them to GitHub.
+            ClearWWWRootTempFolder();
+        }
+
+        private void ClearWWWRootTempFolder()
+        {
+            DirectoryInfo di = new DirectoryInfo(RootDirectoryTools.GetWWWRootTempFolderPhysicalPath());
+
+            foreach (FileInfo file in di.GetFiles())
+            {
+                file.Delete();
+            }
+            foreach (DirectoryInfo dir in di.GetDirectories())
+            {
+                dir.Delete(true);
+            }
+        }
+
     }
 }

--- a/BackEnd/BackEndServer/Views/Camera/CameraSelectionForLocation.cshtml
+++ b/BackEnd/BackEndServer/Views/Camera/CameraSelectionForLocation.cshtml
@@ -14,13 +14,13 @@
                 <div class="card-image clickable">
                     <a href="CameraInformation?cameraId=@camera.CameraId">
                         @{
-                            if (camera.CameraId <= 4)
+                            if (String.IsNullOrWhiteSpace(camera.TempImagePath))
                             {
-                                <img class="camera-card-image" src="~/images/camera_images/camera_image_@(camera.CameraId).png" alt="@camera.CameraRoomName">
+                                <img class="camera-card-image" src="~/images/camera_images/no_location_picture.png" alt="@camera.CameraRoomName">
                             }
                             else
                             {
-                                <img class="camera-card-image" src="~/images/camera_images/no_location_picture.png" alt="@camera.CameraRoomName">
+                                <img class="camera-card-image" src="@(camera.TempImagePath)" alt="@camera.CameraRoomName">
                             }
                         }
                         <span class="camera-card-title card-title">@camera.CameraRoomName</span>

--- a/BackEnd/BackEndServer/Views/Shared/Components/CameraCard/CameraCard.cshtml
+++ b/BackEnd/BackEndServer/Views/Shared/Components/CameraCard/CameraCard.cshtml
@@ -5,16 +5,29 @@
         <div class="col s10 offset-s1">
             <div class="card camera-card">
                 <div class="card-image">
-                    
+
                     @{
-                        if (Model.CameraInformation.CameraId <= 4)
+                        if (String.IsNullOrWhiteSpace(Model.TempImagePath))
                         {
-                            <img class="camera-card-image" src="~/images/camera_images/camera_image_@(Model.CameraInformation.CameraId).png" alt="@Model.CameraInformation.CameraRoomName">
+                            <img class="camera-card-image" src="~/images/camera_images/no_location_picture.png" alt="@Model.CameraInformation.CameraRoomName">
+                        }
+                        else
+                        {
+                            <img class="camera-card-image" src="@Model.TempImagePath" alt="@Model.CameraInformation.CameraRoomName">
+                        }
+
+                        /*
+                        if (String.IsNullOrWhiteSpace(Model.CameraDetails.SavedImagePath) == false)
+                        {
+                            // Convert .NET Framework filepath to HTML URI for the HTML Image element source attribute.
+                            var uri = new System.Uri(Model.CameraDetails.SavedImagePath);
+                            <img class="camera-card-image" src="/Camera/myaction/@(Model.CameraDetails.SavedImagePath)" alt="@Model.CameraInformation.CameraRoomName">
                         }
                         else
                         {
                             <img class="camera-card-image" src="~/images/camera_images/no_location_picture.png" alt="@Model.CameraInformation.CameraRoomName">
                         }
+                        */
                     }
                 </div>
             </div>


### PR DESCRIPTION
- User Story: The two types of pages that must show the user's uploaded images of monitored areas now do so: CameraInformation View and CameraSelectionForLocation View.
- New Helper class: RootDirectoryTools
- Bug fix for #136 : Image Files were being cut off when uploaded to server because they weren't sent asynchronously, so files would be stored corrupted (shown as 0 bytes and not readable if over about 50 kb).
